### PR TITLE
feat: add sepolia testnet

### DIFF
--- a/templates/react/next-ethers5/src/components/Context.tsx
+++ b/templates/react/next-ethers5/src/components/Context.tsx
@@ -12,19 +12,26 @@ type Chain = {
 };
 const zkSync: Chain = {
   id: 324,
-  name: "zkSync Era",
+  name: "zkSync",
   rpcUrl: "https://mainnet.era.zksync.io",
   blockExplorerUrl: "https://explorer.zksync.io"
 }
-const zkSyncTestnet: Chain = {
+const zkSyncSepoliaTestnet: Chain = {
+  id: 300,
+  name: "zkSync Sepolia Testnet",
+  rpcUrl: "https://rpc.ankr.com/eth_sepolia",
+  blockExplorerUrl: "https://sepolia.etherscan.io"
+}
+const zkSyncGoerliTestnet: Chain = {
   id: 280,
-  name: "zkSync Era Testnet",
+  name: "zkSync Goerli Testnet",
   rpcUrl: "https://testnet.era.zksync.dev",
   blockExplorerUrl: "https://goerli.explorer.zksync.io"
 }
 export const chains: Chain[] = [
   zkSync,
-  zkSyncTestnet,
+  zkSyncSepoliaTestnet,
+  zkSyncGoerliTestnet,
   ...(
     process.env.NODE_ENV === "development" ?
     [
@@ -43,7 +50,7 @@ export const chains: Chain[] = [
       : []
     ),
 ];
-export const defaultChain = process.env.NODE_ENV === "development" ? zkSyncTestnet : zkSync;
+export const defaultChain = process.env.NODE_ENV === "development" ? zkSyncSepoliaTestnet : zkSync;
 
 let web3Provider: Web3Provider | null = null;
 

--- a/templates/react/vite-ethers5/src/components/Context.tsx
+++ b/templates/react/vite-ethers5/src/components/Context.tsx
@@ -10,19 +10,26 @@ type Chain = {
 };
 const zkSync: Chain = {
   id: 324,
-  name: "zkSync Era",
+  name: "zkSync",
   rpcUrl: "https://mainnet.era.zksync.io",
   blockExplorerUrl: "https://explorer.zksync.io"
 }
-const zkSyncTestnet: Chain = {
+const zkSyncSepoliaTestnet: Chain = {
+  id: 300,
+  name: "zkSync Sepolia Testnet",
+  rpcUrl: "https://rpc.ankr.com/eth_sepolia",
+  blockExplorerUrl: "https://sepolia.etherscan.io"
+}
+const zkSyncGoerliTestnet: Chain = {
   id: 280,
-  name: "zkSync Era Testnet",
+  name: "zkSync Goerli Testnet",
   rpcUrl: "https://testnet.era.zksync.dev",
   blockExplorerUrl: "https://goerli.explorer.zksync.io"
 }
 export const chains: Chain[] = [
   zkSync,
-  zkSyncTestnet,
+  zkSyncSepoliaTestnet,
+  zkSyncGoerliTestnet,
   ...(
     import.meta.env.MODE === "development" ?
     [
@@ -41,7 +48,7 @@ export const chains: Chain[] = [
       : []
     ),
 ];
-export const defaultChain = import.meta.env.MODE === "development" ? zkSyncTestnet : zkSync;
+export const defaultChain = import.meta.env.MODE === "development" ? zkSyncSepoliaTestnet : zkSync;
 
 let web3Provider: Web3Provider | null = null;
 

--- a/templates/vue/nuxt3-ethers5/store/ethers.ts
+++ b/templates/vue/nuxt3-ethers5/store/ethers.ts
@@ -9,19 +9,26 @@ type Chain = {
 };
 const zkSync: Chain = {
   id: 324,
-  name: "zkSync Era",
+  name: "zkSync",
   rpcUrl: "https://mainnet.era.zksync.io",
   blockExplorerUrl: "https://explorer.zksync.io"
 }
-const zkSyncTestnet: Chain = {
+const zkSyncSepoliaTestnet: Chain = {
+  id: 300,
+  name: "zkSync Sepolia Testnet",
+  rpcUrl: "https://rpc.ankr.com/eth_sepolia",
+  blockExplorerUrl: "https://sepolia.etherscan.io"
+}
+const zkSyncGoerliTestnet: Chain = {
   id: 280,
-  name: "zkSync Era Testnet",
+  name: "zkSync Goerli Testnet",
   rpcUrl: "https://testnet.era.zksync.dev",
   blockExplorerUrl: "https://goerli.explorer.zksync.io"
 }
 export const chains: Chain[] = [
   zkSync,
-  zkSyncTestnet,
+  zkSyncSepoliaTestnet,
+  zkSyncGoerliTestnet,
   ...(
     import.meta.env.MODE === "development" ?
     [
@@ -40,7 +47,7 @@ export const chains: Chain[] = [
       : []
     ),
 ];
-export const defaultChain = import.meta.env.MODE === "development" ? zkSyncTestnet : zkSync;
+export const defaultChain = import.meta.env.MODE === "development" ? zkSyncSepoliaTestnet : zkSync;
 
 export const useEthers = defineStore("ethers", () => {
   let web3Provider: Web3Provider | null = null;

--- a/templates/vue/vite-ethers5/src/ethers.ts
+++ b/templates/vue/vite-ethers5/src/ethers.ts
@@ -10,19 +10,26 @@ type Chain = {
 };
 const zkSync: Chain = {
   id: 324,
-  name: "zkSync Era",
+  name: "zkSync",
   rpcUrl: "https://mainnet.era.zksync.io",
   blockExplorerUrl: "https://explorer.zksync.io"
 }
-const zkSyncTestnet: Chain = {
+const zkSyncSepoliaTestnet: Chain = {
+  id: 300,
+  name: "zkSync Sepolia Testnet",
+  rpcUrl: "https://rpc.ankr.com/eth_sepolia",
+  blockExplorerUrl: "https://sepolia.etherscan.io"
+}
+const zkSyncGoerliTestnet: Chain = {
   id: 280,
-  name: "zkSync Era Testnet",
+  name: "zkSync Goerli Testnet",
   rpcUrl: "https://testnet.era.zksync.dev",
   blockExplorerUrl: "https://goerli.explorer.zksync.io"
 }
 export const chains: Chain[] = [
   zkSync,
-  zkSyncTestnet,
+  zkSyncSepoliaTestnet,
+  zkSyncGoerliTestnet,
   ...(
     import.meta.env.MODE === "development" ?
     [
@@ -41,7 +48,7 @@ export const chains: Chain[] = [
       : []
     ),
 ];
-export const defaultChain = import.meta.env.MODE === "development" ? zkSyncTestnet : zkSync;
+export const defaultChain = import.meta.env.MODE === "development" ? zkSyncSepoliaTestnet : zkSync;
 
 let web3Provider: Web3Provider | null = null;
 const account = ref<{ isConnected: true; address: string; } | { isConnected: false; address: null; }>({


### PR DESCRIPTION
# What :computer: 
* Add zkSync Sepolia Testnet to ethers5 templates

# Why :hand:
* Since zkSync Goerli Testnet is being deprecated

# Evidence :camera:
N/A

# Notes :memo:
* Before updating viem based templates need to firstly add zkSync Sepolia Testnet to `viem/chains` package