### PR TITLE
fix: Incrorrect default contract abi in ethers and ethers5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+package-lock.json

--- a/templates/react/next-ethers/src/components/contracts.ts
+++ b/templates/react/next-ethers/src/components/contracts.ts
@@ -1,6 +1,6 @@
 import IERC20 from "zksync-ethers/abi/IERC20.json";
 
-export const erc20ABI = IERC20.abi;
+export const erc20ABI = IERC20;
 
 export const daiContractConfig = {
   address: '0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b', // zkSync Era Goerli Testnet DAI token address

--- a/templates/react/next-ethers5/src/components/contracts.ts
+++ b/templates/react/next-ethers5/src/components/contracts.ts
@@ -1,6 +1,6 @@
 import IERC20 from "zksync-ethers/abi/IERC20.json";
 
-export const erc20ABI = IERC20.abi;
+export const erc20ABI = IERC20;
 
 export const daiContractConfig = {
   address: '0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b', // zkSync Era Goerli Testnet DAI token address

--- a/templates/react/vite-ethers/src/components/contracts.ts
+++ b/templates/react/vite-ethers/src/components/contracts.ts
@@ -1,6 +1,6 @@
 import IERC20 from "zksync-ethers/abi/IERC20.json";
 
-export const erc20ABI = IERC20.abi;
+export const erc20ABI = IERC20;
 
 export const daiContractConfig = {
   address: '0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b', // zkSync Era Goerli Testnet DAI token address

--- a/templates/react/vite-ethers5/src/components/contracts.ts
+++ b/templates/react/vite-ethers5/src/components/contracts.ts
@@ -1,6 +1,6 @@
 import IERC20 from "zksync-ethers/abi/IERC20.json";
 
-export const erc20ABI = IERC20.abi;
+export const erc20ABI = IERC20;
 
 export const daiContractConfig = {
   address: '0x3e7676937A7E96CFB7616f255b9AD9FF47363D4b', // zkSync Era Goerli Testnet DAI token address


### PR DESCRIPTION
# What :computer: 
* Update `daiContractConfig` imported ABI (`vite-ethers` and `vite-ethers5` templates)
* Also fix same error in `nexr-ethers` and `next-ethers5` templates
* Add `package-lock.json` to gitignore

# Why :hand:
* Error while connecting browser wallet

# Evidence :camera:
![image](https://github.com/matter-labs/zksync-frontend-templates/assets/36932151/793a8008-8a38-4745-889a-ca032d91b4b9)
![image](https://github.com/matter-labs/zksync-frontend-templates/assets/36932151/680086a3-7c68-42cc-8a6a-3bd52d8b8c14)


<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->