### PR TITLE
chore(web3js-vite): carat versioning

### DIFF
--- a/templates/react/vite-web3js/package.json
+++ b/templates/react/vite-web3js/package.json
@@ -13,7 +13,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "web3": "4.11.1",
-    "web3-plugin-zksync": "1.0.0-alpha.0"
+    "web3-plugin-zksync": "^1.0.6"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",


### PR DESCRIPTION
Use carat version specifier to select plugin dependency for Vite + Web3.js template cc @luu-alex 